### PR TITLE
Minor Updates and enhancements to Backup package

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -120,7 +120,8 @@ func TestAcceptance(t *testing.T) {
 		}
 	}
 
-	backup.Runner("test")
+	b := &backup.Backup{}
+	b.Runner("test")
 
 	_, err = c.KV().DeleteTree("", nil)
 	if err != nil {

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -26,20 +26,22 @@ var (
 )
 
 // Setup some basic structs we can use across tests
-func testingStructs() (*consul.Consul, *Backup) {
+func testingStructs() *Backup {
 	consulClient := &consul.Consul{}
 	consulClient.KeyData = kvpairlist
-	backup := &Backup{}
+	backup := &Backup{
+		Client: consulClient,
+	}
 	backup.StartTime = time.Now().Unix()
 
-	return consulClient, backup
+	return backup
 
 }
 
 // just see if we get the same encoded results back
 func TestKeysToJSON(t *testing.T) {
-	consulClient, backup := testingStructs()
-	backup.KeysToJSON(consulClient)
+	backup := testingStructs()
+	backup.KeysToJSON()
 
 	marshallSouce, err := json.Marshal(kvpairlist)
 	if err != nil {
@@ -56,10 +58,10 @@ func TestKeysToJSON(t *testing.T) {
 
 // Write the file locally and then check that we get the same checksum back
 func TestWriteBackupLocal(t *testing.T) {
-	consulClient, backup := testingStructs()
-	backup.KeysToJSON(consulClient)
+	backup := testingStructs()
+	backup.KeysToJSON()
 
-	writeBackupLocal(backup)
+	backup.writeBackupLocal()
 	shacheck := sha256.New()
 
 	filepath := fmt.Sprintf("%v/%v", backup.LocalFilePath, backup.LocalFileName)

--- a/command/backup.go
+++ b/command/backup.go
@@ -2,7 +2,10 @@ package command
 
 import (
 	"fmt"
+
 	"github.com/pshima/consul-snapshot/backup"
+	"github.com/pshima/consul-snapshot/config"
+	"github.com/pshima/consul-snapshot/consul"
 )
 
 // BackupCommand for running backups
@@ -14,7 +17,15 @@ type BackupCommand struct {
 // Run the backup via backup.Runner
 func (c *BackupCommand) Run(args []string) int {
 	c.UI.Info(fmt.Sprintf("v%v: Starting Consul Snapshot", c.Version))
-	response := backup.Runner("constant")
+	conf := config.ParseConfig()
+	client := &consul.Consul{Client: *consul.Client()}
+
+	b := &backup.Backup{
+		Config: conf,
+		Client: client,
+	}
+
+	response := b.Runner("constant")
 	// Actually need to return the proper response here.
 	return response
 }


### PR DESCRIPTION
Instead of passing `backup` and `consul.Client` in a function, use
methods off of the `Backup` type, and inherit the `consul.Client` into
the backup type.