### PR TITLE
Support for Google Cloud Storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-    - 1.6
+    - 1.7
     - tip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2
+* Add support for Google Cloud Storage
+
 ## 0.2.1
 * Bug fix for restore path
 

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,18 @@ deps:
 	go get github.com/Pallinder/go-randomdata
 	go get github.com/mitchellh/cli
 	go get github.com/golang/lint/golint
+	go get golang.org/x/net/context
+	go get google.golang.org/cloud/storage
 	go get
 
 updatedeps:
 	go get -u -v github.com/aws/aws-sdk-go
-	go get -u -v  github.com/hashicorp/consul
-	go get -u -v  github.com/Pallinder/go-randomdata
-	go get -u -v  github.com/mitchellh/cli
-	go get -u -v  github.com/golang/lint/golint
+	go get -u -v github.com/hashicorp/consul
+	go get -u -v github.com/Pallinder/go-randomdata
+	go get -u -v github.com/mitchellh/cli
+	go get -u -v github.com/golang/lint/golint
+	go get -u -v golang.org/x/net/context
+	go get -u -v google.golang.org/cloud/storage
 
 build: deps
 	go build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ deps:
 	go get github.com/Pallinder/go-randomdata
 	go get github.com/mitchellh/cli
 	go get github.com/golang/lint/golint
-	go get golang.org/x/net/context
 	go get google.golang.org/cloud/storage
 	go get
 
@@ -16,7 +15,6 @@ updatedeps:
 	go get -u -v github.com/Pallinder/go-randomdata
 	go get -u -v github.com/mitchellh/cli
 	go get -u -v github.com/golang/lint/golint
-	go get -u -v golang.org/x/net/context
 	go get -u -v google.golang.org/cloud/storage
 
 build: deps

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ consul-snapshot has been used in production since February 2016.
 - Back up K/V Store
 - Back up ACLs
 - Back up Prepared Queries (Consul 0.6.x)
-- Store backups in Amazon S3
-- Restore backups directly from S3
+- Store backups in Amazon S3 / Google Cloud Storage
+- Restore backups directly from S3 / Google Cloud Storage
 - AWS encrypted backups and restores with configurable passphrase
 - Consul compatible health checks for age of last backup
 - Configurable consul settings and backup interval
@@ -43,6 +43,7 @@ Configuration is done from environment variables.
 - S3REGION (the region the s3 bucket is located)
 - AWS_ACCESS_KEY_ID (the access key id used to access the bucket)
 - AWS_SECRET_ACCESS_KEY (the secret key used to access the bucket)
+- GCSBUCKET (the Google Cloud Storage bucket where backups should be delivered)
 - BACKUPINTERVAL (how often you want the backup to run in seconds)
 - CRYPTO_PASSWORD (sets a password for encrypting and decrypting backups)
 - SNAPSHOT_TMP_DIR (sets the directory for temporary files, defaults to "/tmp")

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"bytes"
+  "context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -22,7 +23,6 @@ import (
 	"github.com/pshima/consul-snapshot/consul"
 	"github.com/pshima/consul-snapshot/crypt"
 	"github.com/pshima/consul-snapshot/health"
-	"golang.org/x/net/context"
 	"google.golang.org/cloud/storage"
 )
 

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -2,7 +2,7 @@ package backup
 
 import (
 	"bytes"
-  "context"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ var hostname string
 
 // Config is a struct to hold the backup configuration
 type Config struct {
+	GCSBucket      string
 	S3Bucket       string
 	S3Region       string
 	S3AccessKey    string
@@ -45,6 +46,7 @@ func checkEmpty(s []string) bool {
 
 // Set the environment variables that are required
 func setEnvVars(conf *Config, tests bool) error {
+	conf.GCSBucket = os.Getenv("GCSBUCKET")
 	conf.S3Bucket = os.Getenv("S3BUCKET")
 	conf.S3Region = os.Getenv("S3REGION")
 	conf.S3AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
@@ -76,8 +78,9 @@ func setEnvVars(conf *Config, tests bool) error {
 		if tests {
 			log.Println("Running tests, skipping ENV var requirements")
 		} else {
-			envChecks := []string{conf.S3Bucket, conf.S3Region}
-			if checkEmpty(envChecks) == false {
+			envS3Checks := []string{conf.S3Bucket, conf.S3Region}
+			envGCSChecks := []string{conf.GCSBucket}
+			if checkEmpty(envS3Checks) == false && checkEmpty(envGCSChecks) == false {
 				log.Fatal("[ERR] Required env var missing, exiting")
 			}
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ func TestSetEnvVars(t *testing.T) {
 	os.Setenv("S3REGION", "regiontest")
 	os.Setenv("AWS_ACCESS_KEY_ID", "accesskeytest")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "secretkeytest")
+	os.Setenv("GCSBUCKET", "buckettest")
 	os.Setenv("BACKUPINTERVAL", "60")
 	os.Setenv("SNAPSHOT_TMP_DIR", "/foo")
 	os.Setenv("CRYPTO_PASSWORD", "bar")
@@ -41,6 +42,9 @@ func TestSetEnvVars(t *testing.T) {
 	}
 	if c.S3SecretKey != "secretkeytest" {
 		t.Errorf("Expected %v got %v", "secretkeytest", c.S3SecretKey)
+	}
+	if c.GCSBucket != "buckettest" {
+		t.Errorf("Expected %v got %v", "buckettest", c.GCSBucket)
 	}
 	if c.BackupInterval != 60*time.Second {
 		t.Errorf("Expected %v got %v", 60, c.BackupInterval)
@@ -60,6 +64,7 @@ func TestSetEnvVarsAcceptanceTrue(t *testing.T) {
 	os.Setenv("S3REGION", "regiontest")
 	os.Setenv("AWS_ACCESS_KEY_ID", "accesskeytest")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "secretkeytest")
+	os.Setenv("GCSBUCKET", "buckettest")
 	os.Setenv("BACKUPINTERVAL", "60")
 	os.Setenv("SNAPSHOT_TMP_DIR", "/foo")
 	os.Setenv("ACCEPTANCE_TEST", "asdf")
@@ -78,6 +83,9 @@ func TestSetEnvVarsAcceptanceTrue(t *testing.T) {
 	}
 	if c.S3SecretKey != "secretkeytest" {
 		t.Errorf("Expected %v got %v", "secretkeytest", c.S3SecretKey)
+	}
+	if c.GCSBucket != "buckettest" {
+		t.Errorf("Expected %v got %v", "buckettest", c.GCSBucket)
 	}
 	if c.BackupInterval != 60*time.Second {
 		t.Errorf("Expected %v got %v", 60, c.BackupInterval)
@@ -108,5 +116,4 @@ func TestParseConfig(t *testing.T) {
 	if conf.Hostname != hostname {
 		t.Error("Hostname not being set correctly!")
 	}
-
 }

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	version = "0.2.1"
+	version = "0.2.2"
 )
 
 func main() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -3,6 +3,7 @@ package restore
 import (
 	"bytes"
 	"compress/gzip"
+  "context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,7 +24,6 @@ import (
 	"github.com/pshima/consul-snapshot/config"
 	"github.com/pshima/consul-snapshot/consul"
 	"github.com/pshima/consul-snapshot/crypt"
-	"golang.org/x/net/context"
 	"google.golang.org/cloud/storage"
 )
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -110,6 +110,44 @@ func doWork(conf *config.Config, c *consul.Consul, restorePath string) {
 }
 
 // getRemoteBackup is used to pull backups from S3
+func getRemoteBackupS3(r *Restore, conf *config.Config, outFile *os.File) {
+	s3Conn := session.New(&aws.Config{Region: aws.String(string(conf.S3Region))})
+
+	// Create the params to pass into the actual downloader
+	params := &s3.GetObjectInput{
+		Bucket: &conf.S3Bucket,
+		Key:    &r.RestorePath,
+	}
+
+	log.Printf("[INFO] Downloading %v%v from S3 in %v", string(conf.S3Bucket), r.RestorePath, string(conf.S3Region))
+	downloader := s3manager.NewDownloader(s3Conn)
+	_, err := downloader.Download(outFile, params)
+	if err != nil {
+		log.Fatalf("[ERR] Could not download file from S3!: %v", err)
+	}
+}
+
+// getRemoteBackup is used to pull backups from Google Cloud Storage
+func getRemoteBackupGoogleStorage(r *Restore, conf *config.Config, outFile *os.File) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		log.Fatalf("[ERR] Could not initialize connection with Google Cloud Storage!: %v", err)
+	}
+	rc, err := client.Bucket(conf.GCSBucket).Object(r.RestorePath).NewReader(ctx)
+	log.Printf("[INFO] Downloading %v%v from GCS", string(conf.GCSBucket), r.RestorePath)
+	if err != nil {
+		log.Fatalf("[ERR] Could not download file from GCS!: %v", err)
+	}
+	content, _ := ioutil.ReadAll(rc)
+	_, err = outFile.Write(content)
+	if err != nil {
+		log.Fatalf("[ERR] Could not save file: %v", err)
+	}
+	rc.Close()
+}
+
+// getRemoteBackup is used to pull backups from S3/GoogleStorage
 func getRemoteBackup(r *Restore, conf *config.Config) {
 	r.LocalFilePath = fmt.Sprintf("%v/%v", conf.TmpDir, r.RestorePath)
 
@@ -126,37 +164,9 @@ func getRemoteBackup(r *Restore, conf *config.Config) {
 	}
 
 	if len(string(conf.GCSBucket)) < 1 {
-		s3Conn := session.New(&aws.Config{Region: aws.String(string(conf.S3Region))})
-
-		// Create the params to pass into the actual downloader
-		params := &s3.GetObjectInput{
-			Bucket: &conf.S3Bucket,
-			Key:    &r.RestorePath,
-		}
-
-		log.Printf("[INFO] Downloading %v%v from S3 in %v", string(conf.S3Bucket), r.RestorePath, string(conf.S3Region))
-		downloader := s3manager.NewDownloader(s3Conn)
-		_, err = downloader.Download(outFile, params)
-		if err != nil {
-			log.Fatalf("[ERR] Could not download file from S3!: %v", err)
-		}
+		getRemoteBackupS3(r, conf, outFile)
 	} else {
-		ctx := context.Background()
-		client, err := storage.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("[ERR] Could not initialize connection with Google Cloud Storage!: %v", err)
-		}
-		rc, err := client.Bucket(conf.GCSBucket).Object(r.RestorePath).NewReader(ctx)
-		log.Printf("[INFO] Downloading %v%v from GCS", string(conf.GCSBucket), r.RestorePath)
-		if err != nil {
-			log.Fatalf("[ERR] Could not download file from GCS!: %v", err)
-		}
-		content, _ := ioutil.ReadAll(rc)
-		_, err = outFile.Write(content)
-		if err != nil {
-			log.Fatalf("[ERR] Could not save file: %v", err)
-		}
-		rc.Close()
+		getRemoteBackupGoogleStorage(r, conf, outFile)
 	}
 	outFile.Close()
 	log.Print("[INFO] Download completed")

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -3,7 +3,7 @@ package restore
 import (
 	"bytes"
 	"compress/gzip"
-  "context"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"


### PR DESCRIPTION
Similar to Amazon S3, Google offers Cloud Storage. My patch adds support for GCS and allows to store backups in S3 and GCS if both backends are configured.
