### PR TITLE
Hostname as part of filename

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -211,7 +211,7 @@ func (b *Backup) preProcess() {
 	if b.Config.Acceptance {
 		prefix = "acceptancetest"
 	} else {
-		prefix = fmt.Sprintf("consul.snapshot.%s", startString)
+		prefix = fmt.Sprintf("%s.consul.snapshot.%s", b.Config.Hostname, startString)
 	}
 
 	dir := filepath.Join(b.Config.TmpDir, prefix)
@@ -284,7 +284,7 @@ func (b *Backup) compressStagedBackup() {
 	if b.Config.Acceptance {
 		finalfile = "acceptancetest.tar.gz"
 	} else {
-		finalfile = fmt.Sprintf("consul.snapshot.%s.tar.gz", startString)
+		finalfile = fmt.Sprintf("%s.consul.snapshot.%s.tar.gz", b.Config.Hostname, startString)
 	}
 	finalpath := filepath.Join(b.Config.TmpDir, finalfile)
 	b.FullFilename = finalpath

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -160,7 +160,7 @@ func TestPreProcess(t *testing.T) {
 		t.Error("Generated acl file name is invalid!")
 	}
 
-	prefix := fmt.Sprintf("consul.snapshot.%s", startString)
+	prefix := fmt.Sprintf("%s.consul.snapshot.%s", backup.Config.Hostname, startString)
 	dir := filepath.Join(backup.Config.TmpDir, prefix)
 
 	if backup.LocalFilePath != dir {


### PR DESCRIPTION
With multiple clusters it's useful to keep hostname as part of filename and store all backups in one place. It's also more obvious from where backup came from.