### PR TITLE
Allow user to specify object prefix (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ consul-snapshot has been used in production since February 2016.
 ## Installation
 Grab the binary from [Releases](https://github.com/pshima/consul-snapshot/releases)
 
-With go get: 
+With go get:
 ```
 go get github.com/pshima/consul-snapshot
 ```
 
-From source: 
+From source:
 ```
 git clone https://github.com/pshima/consul-snapshot
 cd consul-snapshot
@@ -46,6 +46,8 @@ Configuration is done from environment variables.
 - BACKUPINTERVAL (how often you want the backup to run in seconds)
 - CRYPTO_PASSWORD (sets a password for encrypting and decrypting backups)
 - SNAPSHOT_TMP_DIR (sets the directory for temporary files, defaults to "/tmp")
+- CONSUL_SNAPSHOT_UPLOAD_PREFIX (an arbitrary prefix to be prepended to the
+  name of each uploaded object, e.g., `consul-dc1`.  Default is `backup`.)
 
 And through the consul api there are several options available (https://github.com/hashicorp/consul/blob/master/api/api.go#L126)
 
@@ -90,7 +92,7 @@ Running a restore:
 
 ## Testing
 
-There are some unit tests but not near full coverage.  
+There are some unit tests but not near full coverage.
 
 There is an acceptance test that:
 - Spins up a local consul agent in dev mode

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -298,12 +298,19 @@ func (b *Backup) compressStagedBackup() {
 // Write the local backup file to S3.
 // There are no tests for this remote operation
 func (b *Backup) writeBackupRemote() {
+	var objectPrefix string
+
 	s3Conn := session.New(&aws.Config{Region: aws.String(string(b.Config.S3Region))})
 
 	t := time.Unix(b.StartTime, 0)
-	remotePath := fmt.Sprintf("backups/%v/%d/%v/%v", t.Year(), t.Month(), t.Day(), filepath.Base(b.FullFilename))
 
-	b.RemoteFilePath = remotePath
+	if b.Config.ObjectPrefix == "" {
+		objectPrefix = "backups"
+	} else {
+		objectPrefix = b.Config.ObjectPrefix
+	}
+
+	b.RemoteFilePath = fmt.Sprintf("%s/%v/%d/%v/%v", objectPrefix, t.Year(), t.Month(), t.Day(), filepath.Base(b.FullFilename))
 
 	// re-read the compressed file.  There is probably a better way to do this
 	localFileContents, err := ioutil.ReadFile(b.FullFilename)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Acceptance     bool
 	Version        string
 	Encryption     string
+	ObjectPrefix   string
 }
 
 // When starting, just set the hostname
@@ -53,6 +54,7 @@ func setEnvVars(conf *Config, tests bool) error {
 	conf.TmpDir = os.Getenv("SNAPSHOT_TMP_DIR")
 	acceptanceTest := os.Getenv("ACCEPTANCE_TEST")
 	conf.Encryption = os.Getenv("CRYPTO_PASSWORD")
+	conf.ObjectPrefix = os.Getenv("CONSUL_SNAPSHOT_UPLOAD_PREFIX")
 
 	// if the environment variable isn't set, just set the dir to /tmp
 	if conf.TmpDir == "" {


### PR DESCRIPTION
If user sets the `CONSUL_SNAPSHOT_UPLOAD_PREFIX` environment variable,
use it instead of `backups` as the path prefix for each object
uploaded to S3.

Closes #11 