### PR TITLE
Add -once flag to backup command

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Pallinder/go-randomdata"
+	randomdata "github.com/Pallinder/go-randomdata"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/pshima/consul-snapshot/backup"
 	"github.com/pshima/consul-snapshot/config"
@@ -124,7 +124,7 @@ func TestAcceptance(t *testing.T) {
 
 	t.Log("Starting Backup")
 
-	backup.Runner("test")
+	backup.Runner("test", true)
 
 	_, err = c.KV().DeleteTree("", nil)
 	if err != nil {

--- a/command/backup.go
+++ b/command/backup.go
@@ -1,8 +1,10 @@
 package command
 
 import (
+	"flag"
 	"fmt"
 
+	"github.com/mitchellh/cli"
 	"github.com/pshima/consul-snapshot/backup"
 )
 
@@ -14,8 +16,17 @@ type BackupCommand struct {
 
 // Run the backup via backup.Runner
 func (c *BackupCommand) Run(args []string) int {
+	// Set flags
+	var flagOnce bool
+	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
+	fs.BoolVar(&flagOnce, "once", false, "")
+	// Parse flags
+	if err := fs.Parse(args); err != nil {
+		return cli.RunResultHelp
+	}
+
 	c.UI.Info(fmt.Sprintf("v%v: Starting Consul Snapshot", c.Version))
-	response := backup.Runner(c.Version)
+	response := backup.Runner(c.Version, flagOnce)
 	// Actually need to return the proper response here.
 	return response
 }
@@ -31,5 +42,8 @@ func (c *BackupCommand) Help() string {
 Usage: consul-snapshot backup
 
 Starts a backup that repeats over an interval.
+
+Options:
+  -once           Run consul-snapshot only once, instead of running on an interval
 `
 }


### PR DESCRIPTION
Adds `-once` flag to backup command, to run a single backup once.

Fixes: #6