### PR TITLE
Dockerfile and nomad jobspec to use docker driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.8-alpine
+
+MAINTAINER Sebastian Montini <sebastian@jampp.com>
+
+RUN apk update \
+  && apk add gcc musl-dev git linux-headers make
+
+RUN go get github.com/pshima/consul-snapshot
+
+COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/consul-snapshot.nomad
+++ b/consul-snapshot.nomad
@@ -1,0 +1,58 @@
+# consul-snapshot nomad jobfile
+job "consul-snapshot" {
+  datacenters = [ "us-east-1" ]
+  region      = "us"
+  type = "service"
+
+  update {
+    max_parallel = 1
+    min_healthy_time = "30s"
+    healthy_deadline = "10m"
+    auto_revert = true
+    canary = 1
+  }
+
+  group "consul-snapshot" {
+    count = 1
+
+    task "backup" {
+      driver = "docker"
+      config {
+        image = "consul-snapshot"
+        args = ["backup"]
+        port_map = {
+          http = 5001
+        }
+      }
+
+      service {
+        port = "http"
+        name = "consul-snapshot"
+        check {
+          type = "http"
+          path = "/health"
+          interval = "10s"
+          timeout = "2s"
+        }
+      }
+
+      env {
+        "S3BUCKET" = "backups.example.bucket"
+        "S3REGION" = "us-east-1"
+        "BACKUPINTERVAL" = 300
+        "CONSUL_HTTP_ADDR" = "consul.example.com:8500"
+      }
+
+      resources {
+        cpu = 100
+        memory = 256
+        network {
+          mbits = 100
+          port "http" {
+          }
+        }
+      }
+
+    }
+  }
+}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+run_app() {
+  consul-snapshot "${@}"
+}
+
+case "${1}" in
+  'backup')
+    run_app "${1}"
+    ;;
+
+  'restore')
+    run_app "${@}"
+    ;;
+
+  *)
+    exec "${@}"
+    ;;
+
+esac


### PR DESCRIPTION
I added a simple dockerfile and docker-entryproint so you can build a publish a docker image of consul-snapshot.

we're running it with nomad as a service, using the docker driver works great.
also, if you use nomad and docker, using https://github.com/lyft/metadataproxy works great, since you can use an ENV for indicating the IAM_ROLE you want your consul-snapshot docker to be run with.